### PR TITLE
Fix date ranges and ISO codes

### DIFF
--- a/coup.monthly/f.yrmorack.R
+++ b/coup.monthly/f.yrmorack.R
@@ -273,13 +273,21 @@ f.yrmorack <- function(startdate, enddate) {
           NorthVietnam, SouthVietnam)
 
      # Aggregate
-     tmpdate <- as.Date(lubridate::ymd(paste0(rack$year, "-", rack$month, "-01")))
-     rack <- rack[tmpdate > startdate,]
-     
      rack <- as.data.frame(rbind(africa, americas, asia, europe, fsu, oceania, defunct),
           stringsAsFactors = FALSE)
      
+     print(unique(rack$country))
+     rack$iso3c <- countrycode::countrycode(rack$country, "country.name", "iso3c")
+     rack[rack$country=="North Yemen", "iso3c"] <- "YEM"
+     rack[rack$country=="South Yemen", "iso3c"] <- "YMD"
+     rack[rack$country=="North Vietnam", "iso3c"] <- "VDR"
+     rack[rack$country=="Serbia and Montenegro", "iso3c"] <- "YMD"
+     rack[rack$country=="Soviet Union", "iso3c"] <- "SUN"
+     rack[rack$country=="Serbia and Montenegro", "iso3c"] <- "SCG"
 
+     tmpdate <- as.Date(lubridate::ymd(paste0(rack$year, "-", rack$month, "-01")))
+     rack <- rack[tmpdate >= startdate,]
+     print(unique(rack$country))
      return(rack)
 
 }

--- a/coup.monthly/f.yrmorack.R
+++ b/coup.monthly/f.yrmorack.R
@@ -13,11 +13,12 @@
 #
 # Frame <- f.yrmorack("1960-01-01", "2013-12-31")
 #
-# makes a country-month data set ranging from Jan 1960 to Dec 2013. The result includes three columns:
+# makes a country-month data set ranging from Jan 1960 to Dec 2013. The result includes four columns:
 #
 # country (str) -- country name, e.g., "Afghanistan"
 # year (int) -- the year, e.g., 1960
 # month (int) -- the month, e.g., 1
+# iso3c (str) -- the ISO code, e.g., "AFG"
 #
 # Country list and most dates sourced to:
 # Wikipedia: http://en.wikipedia.org/wiki/List_of_sovereign_states_by_date_of_formation

--- a/coup.monthly/f.yrmorack.R
+++ b/coup.monthly/f.yrmorack.R
@@ -276,7 +276,6 @@ f.yrmorack <- function(startdate, enddate) {
      rack <- as.data.frame(rbind(africa, americas, asia, europe, fsu, oceania, defunct),
           stringsAsFactors = FALSE)
      
-     print(unique(rack$country))
      rack$iso3c <- countrycode::countrycode(rack$country, "country.name", "iso3c")
      rack[rack$country=="North Yemen", "iso3c"] <- "YEM"
      rack[rack$country=="South Yemen", "iso3c"] <- "YMD"
@@ -287,7 +286,6 @@ f.yrmorack <- function(startdate, enddate) {
 
      tmpdate <- as.Date(lubridate::ymd(paste0(rack$year, "-", rack$month, "-01")))
      rack <- rack[tmpdate >= startdate,]
-     print(unique(rack$country))
      return(rack)
 
 }

--- a/coup.monthly/f.yrmorack.R
+++ b/coup.monthly/f.yrmorack.R
@@ -273,8 +273,12 @@ f.yrmorack <- function(startdate, enddate) {
           NorthVietnam, SouthVietnam)
 
      # Aggregate
+     tmpdate <- as.Date(lubridate::ymd(paste0(rack$year, "-", rack$month, "-01")))
+     rack <- rack[tmpdate > startdate,]
+     
      rack <- as.data.frame(rbind(africa, americas, asia, europe, fsu, oceania, defunct),
           stringsAsFactors = FALSE)
+     
 
      return(rack)
 


### PR DESCRIPTION
These changes fix two things:
https://twitter.com/dtchimp/status/583030936436084736
- Countries that died before the start date of the dataset are no longer included.
- The `rack` dataframe that the function returns now includes ISO codes for all countries. The `countrycode` package gets almost all, but some defunct countries need hand coding, so I built the ISO code process into the function.

Note: the function now depends on the `countrycode` and `lubridate` packages. Also, there is the potential for some very weird edge cases for countries that still exist but have changed ISO codes. I'm thinking here of Zaire (ZAR) becoming D.R. Congo (COD). I can only imagine this happening with historical data that used the contemporaneous ISO codes. See the [wikipedia page](http://en.wikipedia.org/wiki/ISO_3166-3) on defunct ISO codes for more.
